### PR TITLE
Updated Widget Naming Convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Any Addicitonal questions can be asked to quentin via canvas [here](https://canv
 For this project, use __camelCase__ with the following conventions for elements:
 
 - Blueprints = BP_myBlueprint
-- UIWidgets = BP_myWidget
+- UIWidgets = W_myWidget
 - Interfaces = I_myInterface
 - Structs = S_myStruct
 - Materials = M_myMat


### PR DESCRIPTION
Updated Readme to contain new naming convention for blueprint widgets from BP_myWidget to W_myWidget This avoids confusion between widget blueprints and gameplay / logic blueprints.

- [ ] TODO: Update all current widget names to new convention at start of next sprint / main commit